### PR TITLE
Need to add "token " to the authorization header

### DIFF
--- a/ExampleCode/SAM/REST/Services/Github/src/main/java/com/oracle/github/RestController.java
+++ b/ExampleCode/SAM/REST/Services/Github/src/main/java/com/oracle/github/RestController.java
@@ -47,7 +47,7 @@ public class RestController {
 		Set<String> tempFilteredGithubData = new HashSet<String>();		
 		RestTemplate restTemplate = null;
 		HttpHeaders headers = new HttpHeaders();
-		headers.add("Authorization", gitConnect.getAuthToken());
+		headers.add("Authorization", "token " + gitConnect.getAuthToken());
 		
 		ApiTemplate apiTemplate = new ApiTemplate();
 		restTemplate = apiTemplate.createSSLBasedRestTemplateWithBasicCredentials(gitConnect.getSslRESTTemplateHost(), gitConnect.getSslRESTTemplatePort(), gitConnect.getSslRESTTemplateScheme());


### PR DESCRIPTION
This is a requirement for accessing private repositories. Without this authentication fails.
Validated the fix on a private repository.