### PR TITLE
Clearify ConstrainInputPW.js

### DIFF
--- a/ExampleCode/Open UI/Constrain User Input/ConstrainInputPW.js
+++ b/ExampleCode/Open UI/Constrain User Input/ConstrainInputPW.js
@@ -1,7 +1,7 @@
 if (typeof(SiebelAppFacade.ConstrainInputPW) === "undefined") {
 
 	SiebelJS.Namespace("SiebelAppFacade.ConstrainInputPW");
-	define("siebel/custom/ConstrainInputPW", [],
+	define("siebel/custom/ConstrainInputPW", ["siebel/pwinfra"],
 		function () {
 		SiebelAppFacade.ConstrainInputPW = (function () {
 
@@ -14,14 +14,12 @@ if (typeof(SiebelAppFacade.ConstrainInputPW) === "undefined") {
 			ConstrainInputPW.prototype.BindEvents = function () {
 				SiebelAppFacade.ConstrainInputPW.superclass.BindEvents.apply(this, arguments);
 				$(this.GetEl()).keypress(function (e) {
-					var a = [];
-					var k = e.which;
+					var keys = [44, 46];	//	comma, period
 
 					for (i = 48; i < 58; i++)
-						a.push(i);
-					a.push(46); //period
+						keys.push(i);	//	digits
 
-					if (!(a.indexOf(k) >= 0))
+					if (!(keys.includes(e.which)))
 						e.preventDefault();
 
 				});


### PR DESCRIPTION
- Adding missing reference to ["siebel/pwinfra"] (is this needed?)
- Removed var 'k' because it is called only once.
- Change var 'a' to meaningful var 'keys'.
- Combine declaration and assigning of var 'keys' in one line.
- Adding comma to support European version ofdecimal sign.
- Replace IndexOf with includes, which gives a better understanding what it tries to do.