### PR TITLE
Update mde_install.sh

### DIFF
--- a/Containerization/Docker/oraclelinux/classic-mde/build/multi-stage/mde/mde_install.sh
+++ b/Containerization/Docker/oraclelinux/classic-mde/build/multi-stage/mde/mde_install.sh
@@ -12,8 +12,7 @@ chown -R siebel:siebel /config
 
 # Run the silent installer
 
-su siebel -c "bash /mnt/Siebel_Enterprise_Server/Disk1/install/runInstaller.sh -silent -responseFile /config/mde.rsp -invPtrLoc /config/oraInst.loc -waitforcom
-pletion -showProgress > /config/SiebelInstall.log 2>&1"
+su siebel -c "bash /mnt/Siebel_Enterprise_Server/Disk1/install/runInstaller.sh -silent -responseFile /config/mde.rsp -invPtrLoc /config/oraInst.loc -waitforcompletion -showProgress > /config/SiebelInstall.log 2>&1"
 res=$?
 more /config/SiebelInstall.log
 if grep "\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*Error\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*" /config/SiebelInstall.log; then


### PR DESCRIPTION
Command line splits from line 15 to 16 causing the following error:

"... bash: line 1: pletion: command not found
The command '/bin/sh -c mkdir -p -ma+rwx /siebel/ses /siebel/oraInventory  /stage && groupadd -g  1000 siebel && useradd 
-m -g siebel -G siebel -u 1000 siebel && cd /mnt && date && echo Downloading installer && bash /config/getMDE.sh ${INSTAL
LSITE} ${VERSION}&& chmod a+rx /config && chown -R siebel:siebel /config && date && chmod +x /mnt/Siebel_Enterprise_Serve
r/Disk1/install/unzip && chmod +x /mnt/Siebel_Enterprise_Server/Disk1/install/runInstaller && cd / && echo Installing Sie
bel ... && bash /config/mde_install.sh && rm -rf /mnt/Siebel_Enterprise_Server/ && echo Waiting for deployment of web arc
hives ... && sleep 15 && chown -R siebel:siebel /siebel && chmod -R 755 /siebel/ses && sed -i 's/-t 90/-t 30/g' /siebel/m
de/siebsrvr/admin/common.scm && sed -i 's/-t 90/-t 30/g' /siebel/mde/gtwysrvr/admin/common.scm && cd /siebel/mde/applicat
ioncontainer_external/siebelwebroot && mkdir -p ara chs cht csy dan deu enu esn fin fra heb ita jpn kor nld plk ptb ptg r
us sve tha trk && bash /config/processRemovals /config/siebelRemovalList' returned a non-zero code: 127... "