### PR TITLE
Update DoubleClickProcessingPR.js

### DIFF
--- a/ExampleCode/Open UI/Double Click/DoubleClickProcessingPR.js
+++ b/ExampleCode/Open UI/Double Click/DoubleClickProcessingPR.js
@@ -26,11 +26,11 @@ if (typeof(SiebelAppFacade.DoubleClickProcessingPR) === "undefined") {
 				});
 				$("#" + appletId).find("#sieb-ui-popup-mvg-available").find(".ui-jqgrid-view").dblclick(function () {
 					pm.ExecuteMethod("InvokeMethod", "AddRecord");
-					pm.ExecuteMethod("InvokeMethod", "ExecuteQuery");
+					//pm.ExecuteMethod("InvokeMethod", "ExecuteQuery"); //3.04.23: deactivated due Bug 36212976 : ALT+ENTER SHORTCUT KEYS NOT WORKING IN MULTI-TAB SCENARIO
 				});
 				$("#" + appletId).find("#sieb-ui-popup-mvg-selected").find(".ui-jqgrid-view").dblclick(function () {
 					pm.ExecuteMethod("InvokeMethod", "DeleteRecords");
-					pm.ExecuteMethod("InvokeMethod", "ExecuteQuery");
+					//pm.ExecuteMethod("InvokeMethod", "ExecuteQuery");  //3.04.23: deactivated due Bug 36212976 : ALT+ENTER SHORTCUT KEYS NOT WORKING IN MULTI-TAB SCENARIO
 				});
 			}
 


### PR DESCRIPTION
due "Bug 36212976 : ALT+ENTER SHORTCUT KEYS NOT WORKING IN MULTI-TAB SCENARIO" the code lines 'pm.ExecuteMethod("InvokeMethod", "ExecuteQuery")' have to be commented out. The MVG applet is close after double click. The assoc applet remains open.